### PR TITLE
Subir Docker Image a Nexus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+FROM anapsix/alpine-java:8_server-jre
+
+ENV PATH=/usr/local/bin:${PATH}
+
+
+    # Prepare the container to install the software
+RUN set -ex && \
+    apk upgrade --update && \
+    apk add --update curl mariadb mariadb-client supervisor && \
+    rm -rf /var/cache/apk/* && \
+    # Remove not needed tools
+    apk del curl && \
+    # Mysql
+    mysql_install_db --user=mysql --rpm && \
+    (mysqld_safe &) && \
+    sleep 2  
+    # mysql -u root -e "GRANT ALL ON druid.* TO 'druid'@'localhost' IDENTIFIED BY 'diurd'; CREATE database druid CHARACTER SET utf8;" && \
+
+RUN apk   add maven
+
+
+ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Expose ports:
+# - 8081: HTTP (coordinator)
+# - 8082: HTTP (broker)
+# - 8083: HTTP (historical)
+# - 3306: MySQL
+# - 2181 2888 3888: ZooKeeper
+# mysqld start --user=root
+
+
+RUN rm -R /var/lib/mysql/*
+RUN mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql
+ 
+
+COPY . ./home/journals/
+
+ 
+CMD ["mvn", "dependency:go-offline -B"]
+COPY ./Code/target/journals-1.0.jar  ./home/journals/Code/target
+
+EXPOSE 8080 3306
+
+
+#RUN mysqld  --user=root  
+ENTRYPOINT ./home/journals/docker-entrypoint.sh
+
+#ENTRYPOINT export HOSTIP="$(resolveip -s $HOSTNAME)" && exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/README.md
+++ b/README.md
@@ -120,6 +120,16 @@ docker run  --privileged --name journals_app  -p 8080:8080 -ti afaa7c0506e7
 
 A disfrutar!
 
+
+
+## Ansible para automatizar la publicación
+
+
+```
+ansible-playbook docker-publish.yml --extra-vars "version=1.1"
+```
+
+
 # Contact
 
 Cualquier duda o consulta, ubicanos en [Slack](https://semperti.slack.com).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,98 @@ Repositorio para los assignments de la primer semana.
 		2. public users:
 			- username: user1 / password: user1
 			- username: user2 / password: user2
+
+
+
+## Publicar imagen en DockerHub
+
+Como primer paso debemos tener cuenta en Docker y un repositorio.
+En caso de no tener alguno de los dos, ingresamos a hub.docker.com, nos registramos y presionamos en la opcion de create repository.
+
+Por consola realizamos el login
+
+```
+docker login --username=jsfrnc
+
+```
+Listamos las imagenes que tenemos en el sistema, deberiamos tener la que ya generamos en los ejercicios anteriores (journals), si revisamos su IMAGE ID es afaa7c0506e7 este valor lo vamos a usar adelante.
+```
+docker images
+REPOSITORY            TAG                 IMAGE ID            CREATED             SIZE
+journals              latest              afaa7c0506e7        23 minutes ago      834MB
+anapsix/alpine-java   8_server-jre        f8388f56eae6        11 months ago       126MB
+
+```
+
+Ahora generamos el tag del numera de imagen, contra el repositorio remoto, el mismo es formado con el @user/@repository_name.
+
+```
+docker tag afaa7c0506e7 jsfrnc/semperti-bootcamp:firsttry
+
+```
+Una vez realizado esto, hacemos el push de nuestro tag.
+
+```
+docker push jsfrnc/semperti-bootcamp:firsttry
+The push refers to repository [docker.io/jsfrnc/semperti-bootcamp]
+9269dc392487: Pushed
+2fb9d21a73e6: Pushed
+be230368975c: Pushed
+6831f6961390: Pushed
+497269e0b369: Pushed
+9cabc3fe13d9: Pushed
+548034a34f42: Pushed
+e3a37bc06bf3: Mounted from anapsix/alpine-java
+767f936afb51: Mounted from anapsix/alpine-java
+firsttry: digest: sha256:8376360c4a63a30e65a9a0abda9871e2db7e05127929bccfe7e30973f4817351 size: 2212
+
+```
+Si tuvimos existo la misma ya deberia estar en nuestro repositorio de Docker Hub, por ejemplo para este caso quedo publicado en https://hub.docker.com/layers/jsfrnc/semperti-bootcamp/firsttry/images/sha256-8376360c4a63a30e65a9a0abda9871e2db7e05127929bccfe7e30973f4817351
+
+Para algunos casos, si quisieramos exportar nuestra imagen en tar podriamos hacer lo siguiente:
+```
+docker save afaa7c0506e7 > semperti-bootcam.tar 
+
+```
+
+Para importarla seria de la siguiente manera.
+```
+docker  load --input semperti-bootcam.tar 
+
+```
             
+
+## Descargar imagen de DockerHub
+Buscamos la imagen a usar, en este caso vamos a usar la que publicamos en el caso anterior jsfrnc/semperti-bootcamp:firsttry. 
+
+```
+docker pull jsfrnc/semperti-bootcamp:firsttry
+firsttry: Pulling from jsfrnc/semperti-bootcamp
+169185f82c45: Pull complete
+390eaa747a6b: Downloading [===========>                                       ]  10.41MB/46.51MB
+12116bdc6872: Downloading [==========>                                        ]  12.32MB/58.59MB
+4b9c6521136c: Downloading [============>                                      ]  16.09MB/63.11MB
+955786db6e7a: Waiting
+7863b0acb235: Waiting
+55e6c8b76ec4: Waiting
+ae5b84ee592e: Waiting
+4fda7eef105f: Waiting
+```
+Una vez descargada listamos las imagenes que tenemos local, y copiamos el image id.
+
+```
+docker images
+REPOSITORY                 TAG                 IMAGE ID            CREATED             SIZE
+jsfrnc/semperti-bootcamp   firsttry            afaa7c0506e7        About an hour ago   834MB
+```
+
+Ahora iniciamos con docker un nuevo container haciendo referencia a nuestra imagen -ti {IMAGE ID}
+```
+docker run  --privileged --name journals_app  -p 8080:8080 -ti afaa7c0506e7
+```
+
+A disfrutar!
+
 # Contact
 
 Cualquier duda o consulta, ubicanos en [Slack](https://semperti.slack.com).

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 mysqld --user=root  &
-java -jar ./home/journals/Code/target/journals-1.0.jar
+java -jar ./home/journals/Code/target/journals-*.jar

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mysqld --user=root  &
+java -jar ./home/journals/Code/target/journals-1.0.jar

--- a/docker-publish.retry
+++ b/docker-publish.retry
@@ -1,0 +1,1 @@
+localhost

--- a/docker-publish.yml
+++ b/docker-publish.yml
@@ -1,0 +1,25 @@
+---
+
+    - name: Publicacion de Docker a DockerHub
+      connection: network_cli
+      gather_facts: false
+      hosts: all
+      vars:
+          srcpath: ./Code
+          version: "{{ version }}"
+      tasks:
+  
+        - name: Docker Build
+          shell: "docker build -rm -t journals-{{version}} {{ srcpath }} "
+
+        - name: Tageamos la version
+          shell: "docker tag journals-{{version}} jsfrnc/bootcamp-journals:{{version}}"
+          
+        - name: Push Docker
+          shell: "docker push jsfrnc/bootcamp-journals:{{version}}"
+ 
+           
+ 
+
+
+ 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,13 @@
+[supervisord]
+nodaemon=true
+loglevel=debug
+
+[program:zookeeper]
+command=/usr/local/zookeeper/bin/zkServer.sh start-foreground
+user=daemon
+priority=0
+
+[program:mysql]
+command=/usr/bin/mysqld_safe
+user=mysql
+priority=0


### PR DESCRIPTION
La imagen de Docker debe quedar accesible desde Nexus
Se debe proveer el comando para subir una imagen a Nexus junto con un comando para descargar la imagen y correr el contenedor
Debe proveerse el sistema lógico de taggeo de imágenes

